### PR TITLE
Centralize plugin info into info.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ Also supports:
    - This file can usually be found in the [OpenRCT2 installation directory](#openrct2-installation-directory).
    - Alternatively you can download the file from Github [here](https://raw.githubusercontent.com/OpenRCT2/OpenRCT2/develop/distribution/openrct2.d.ts).
    - Another option is to make a symbolic link instead of copying the file, which will keep the file up to date whenever you install new versions of OpenRCT2.
-7. In `./src/plugin.ts`, change the name and author of the plugin to your liking.
-8. In `./rollup.config.js`, change the filename of the outputted plugin.
+7. In `./src/info.js`, change plugin info, such as name and author, to your liking.
 
 ---
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,6 +2,7 @@ import resolve from "@rollup/plugin-node-resolve";
 import terser from "@rollup/plugin-terser";
 import typescript from "@rollup/plugin-typescript";
 import { getConfigHome, getDocumentsFolder } from "platform-folders";
+import { filename } from "./src/info.js";
 
 
 const options =
@@ -9,7 +10,7 @@ const options =
 	/**
 	 * Change the file name of the output file here.
 	 */
-	filename: "my-plugin.js",
+	filename: filename,
 
 	/**
 	 * Determines in what build mode the plugin should be build. The default here takes

--- a/src/info.js
+++ b/src/info.js
@@ -10,9 +10,7 @@ export const type = "remote";
 /**
  * The following fields determine which OpenRCT2 API version to use. It's best to always target
  * the latest release version, unless you want to use specific versions from a newer develop
- * version. Keep the min version as null unless it is different than the target.
- * Version 77 equals the v0.4.5 release.
+ * version. Version 77 equals the v0.4.5 release.
  * @see https://github.com/OpenRCT2/OpenRCT2/blob/v0.4.5/src/openrct2/scripting/ScriptEngine.h#L50
  */
-export const minApiVersion = null;
 export const targetApiVersion = 77;

--- a/src/info.js
+++ b/src/info.js
@@ -1,0 +1,18 @@
+export const filename = "my-plugin.js";
+
+export const name = "Name of your plugin";
+export const authors = [ "Your name" ];
+export const version = "1.0";
+export const license = "MIT";
+
+export const type = "remote";
+
+/**
+ * The following fields determine which OpenRCT2 API version to use. It's best to always target
+ * the latest release version, unless you want to use specific versions from a newer develop
+ * version. Keep the min version as null unless it is different than the target.
+ * Version 77 equals the v0.4.5 release.
+ * @see https://github.com/OpenRCT2/OpenRCT2/blob/v0.4.5/src/openrct2/scripting/ScriptEngine.h#L50
+ */
+export const minApiVersion = null;
+export const targetApiVersion = 77;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -2,18 +2,16 @@
 
 import { startup } from "./startup";
 
+// @ts-ignore
+import * as info from "./info.js";
+
 registerPlugin({
-	name: "Name of your plugin",
-	version: "1.0",
-	authors: [ "Your name" ],
-	type: "remote",
-	licence: "MIT",
-	/**
-	 * This field determines which OpenRCT2 API version to use. It's best to always use the
-	 * latest release version, unless you want to use specific versions from a newer develop
-	 * version. Version 70 equals the v0.4.4 release.
-	 * @see https://github.com/OpenRCT2/OpenRCT2/blob/v0.4.4/src/openrct2/scripting/ScriptEngine.h#L50
-	 */
-	targetApiVersion: 70,
+	name: info.name,
+	version: info.version,
+	authors: info.authors,
+	type: info.type,
+	licence: info.license,
+	minApiVersion: info.minApiVersion ?? info.targetApiVersion,
+	targetApiVersion: info.targetApiVersion,
 	main: startup,
 });

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -11,7 +11,6 @@ registerPlugin({
 	authors: info.authors,
 	type: info.type,
 	licence: info.license,
-	minApiVersion: info.minApiVersion ?? info.targetApiVersion,
 	targetApiVersion: info.targetApiVersion,
 	main: startup,
 });

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -1,3 +1,6 @@
+// @ts-ignore
+import * as info from "./info.js";
+
 function onClickMenuItem()
 {
 	// Write code here that should happen when the player clicks the menu item under the map icon.
@@ -15,6 +18,6 @@ export function startup()
 	// Register a menu item under the map icon:
 	if (typeof ui !== "undefined")
 	{
-		ui.registerMenuItem("My plugin", () => onClickMenuItem());
+		ui.registerMenuItem(info.name, () => onClickMenuItem());
 	}
 }


### PR DESCRIPTION
This fixes two problems with the template:

1. A developer needed to go into two files to change the name of the plugin: once to register it to OpenRCT2, and again to change how it displays in the map dropdown
2. `rollup.config.js` needed to be edited for the exported filename to change, which broke the pattern of the `src` folder being the only folder to edit to make changes to the plugin

Now, a new file named `info.js` exports variables which the developer can change. This is for the most part a refactor, though a few (very minor) things distinct this from the previous version:

- The `README.md` file has been updated to reflect the singular location where a developer would need to update information
- The target API version is now 77 to match OpenRCT2's `v0.4.5` release
- By default, the name of the plugin registered to OpenRCT2 matches what displays in the map dropdown (I don't believe this will cause controversy, as it's unlikely someone would want these to be different from each other)
- A developer can now set a `minApiVersion` from `info.js` (while this is technically different, it doesn't affect functionality given a developer could have added the parameter themselves; this just makes it so that all information is explicit in the `info.js` file)