### PR TITLE
Add support for native-feeling async behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "1.0.0",
 			"license": "MIT",
 			"devDependencies": {
+				"@rollup/plugin-inject": "^5.0.5",
 				"@rollup/plugin-node-resolve": "^15.0.1",
 				"@rollup/plugin-terser": "^0.4.0",
 				"@rollup/plugin-typescript": "^11.0.0",
@@ -80,6 +81,28 @@
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
 			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
 			"dev": true
+		},
+		"node_modules/@rollup/plugin-inject": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.5.tgz",
+			"integrity": "sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==",
+			"dev": true,
+			"dependencies": {
+				"@rollup/pluginutils": "^5.0.1",
+				"estree-walker": "^2.0.2",
+				"magic-string": "^0.30.3"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"rollup": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/@rollup/plugin-node-resolve": {
 			"version": "15.1.0",
@@ -481,6 +504,15 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.12.0"
+			}
+		},
+		"node_modules/magic-string": {
+			"version": "0.30.10",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
+			"integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.4.15"
 			}
 		},
 		"node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 		"build:dev": "rollup --config rollup.config.js"
 	},
 	"devDependencies": {
+		"@rollup/plugin-inject": "^5.0.5",
 		"@rollup/plugin-node-resolve": "^15.0.1",
 		"@rollup/plugin-terser": "^0.4.0",
 		"@rollup/plugin-typescript": "^11.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,7 +4,8 @@ import typescript from "@rollup/plugin-typescript";
 import { exec } from "child_process";
 import { homedir } from "os";
 import { promisify } from "util";
-
+import inject from "@rollup/plugin-inject";
+import path from "path";
 
 const options =
 {
@@ -70,6 +71,9 @@ const config = {
 	},
 	treeshake: "smallest",
 	plugins: [
+		inject({
+			Promise: [path.resolve("src/polyfills/promisePolyfill.ts"), "PromisePolyfill"],
+		  }),
 		resolve(),
 		typescript(),
 		terser({

--- a/src/polyfills/nextTick.ts
+++ b/src/polyfills/nextTick.ts
@@ -1,0 +1,21 @@
+/**
+ * Use this function to pause an expensive calculation and continue it during the next tick.
+ * See example usage [here](https://gist.github.com/IntelOrca/a9f90c930d8fa2e04877281be5f8481b)
+ *
+ */
+export function nextTick() {
+  return new Promise<void>((resolve, reject) => {
+    try {
+      const subscription = context.subscribe("interval.tick", () => {
+        try {
+          subscription.dispose();
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+    } catch (e) {
+      reject(e);
+    }
+  });
+}

--- a/src/polyfills/promisePolyfill.ts
+++ b/src/polyfills/promisePolyfill.ts
@@ -1,0 +1,95 @@
+//@ts-nocheck
+
+/**
+ * This polyfill, plus some bundle and compilation settings, allows the use of Promise and async
+ * in your plugin code. See usage in [nextTick.ts](./nextTick.ts)
+ */
+function PromisePolyfill(executor) {
+  let onResolve, onReject;
+  let fulfilled = false,
+    rejected = false,
+    called = false,
+    value;
+
+  function resolve(v) {
+    fulfilled = true;
+    value = v;
+
+    if (typeof onResolve === "function") {
+      console.log("HELLO");
+      onResolve(value);
+      called = true;
+    }
+  }
+
+  function reject(reason) {
+    rejected = true;
+    value = reason;
+
+    if (typeof onReject === "function") {
+      onReject(value);
+      called = true;
+    }
+  }
+
+  this.then = function (callback) {
+    onResolve = callback;
+
+    if (fulfilled && !called) {
+      called = true;
+      onResolve(value);
+    }
+    return this;
+  };
+
+  this.catch = function (callback) {
+    onReject = callback;
+
+    if (rejected && !called) {
+      called = true;
+      onReject(value);
+    }
+    return this;
+  };
+
+  try {
+    executor(resolve, reject);
+  } catch (error) {
+    reject(error);
+  }
+}
+
+PromisePolyfill.resolve = (val) =>
+  new PromisePolyfill(function executor(resolve, _reject) {
+    resolve(val);
+  });
+
+PromisePolyfill.reject = (reason) =>
+  new PromisePolyfill(function executor(resolve, reject) {
+    reject(reason);
+  });
+
+PromisePolyfill.all = (promises) => {
+  let fulfilledPromises = [],
+    result = [];
+
+  function executor(resolve, reject) {
+    promises.forEach((promise, index) =>
+      promise
+        .then((val) => {
+          fulfilledPromises.push(true);
+          result[index] = val;
+
+          if (fulfilledPromises.length === promises.length) {
+            return resolve(result);
+          }
+        })
+        .catch((error) => {
+          return reject(error);
+        })
+    );
+  }
+  return new PromisePolyfill(executor);
+};
+
+export { PromisePolyfill };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
 		"outDir": "out",
 		"strict": true,
 		"target": "es5",
-		"lib": [ "es5" ]
+		"lib": [ "es5", "ES2015.Promise"]
 	},
 	"include": [
 		"./lib/**/*.ts",


### PR DESCRIPTION
After reading the conversation in #plugin today, I thought it would be worth exposing the async feel into this template. 

Key changes:
* Add a polyfill for promises and instruct Rollup to roll that into the bundle. (This was much more annoying to get right than I thought it would be)
* Add Promise, await, async, etc. type support by adding "ES2015.Promise" into the tsconfig lib.
* Use IntelOrca's nextTick implementation as a recommended way of interactiong with long-running processes. 

I think the [linked example](https://gist.github.com/IntelOrca/a9f90c930d8fa2e04877281be5f8481b) sets good expectations for usage, but I'm not sure how easy this code is to misuse. It'd be helpful to get some other feedback from others about if it does/doesn't meet their expectations. 